### PR TITLE
Watcher.__init__(): doc: block to watch variable

### DIFF
--- a/kurt/__init__.py
+++ b/kurt/__init__.py
@@ -862,7 +862,7 @@ class Watcher(Actor):
 
         For variables::
 
-            kurt.Block('getVar:', 'variable name')
+            kurt.Block('readVariable', 'variable name')
 
         For lists::
 


### PR DESCRIPTION
To construct a watcher for a variable, the block should be
'readVariable' not 'getVar:' (which is not recognised as a block).

(The final project file does need to specify 'getVar:'; the conversion
is done in

    scratch20.ZipWriter.save_watcher()
    scratch14.Serializer.save_watcher()

on the way out and

    scratch20.ZipReader.load_watcher()
    scratch14.Serializer.load_watcher()

on the way in.)